### PR TITLE
feature: add ability to mutate lump metadata

### DIFF
--- a/src/bin/dump.rs
+++ b/src/bin/dump.rs
@@ -13,7 +13,9 @@ fn main() {
   println!("{bsp:#?}");
 
   for i in 0..LUMP_COUNT {
-    let lump = bsp.lump(i);
+    let (metadata, lump) = bsp.lump(i);
+
     println!("lump {i}: {} bytes", lump.len());
+    println!("metadata: {metadata:#?}");
   }
 }


### PR DESCRIPTION
Closes #1 

`LumpDescriptor` and `LumpMetadata` names definitely need some work, but I'll file a new issue for this so it can be handled in the future.